### PR TITLE
Fix broken getParams call for Neo4j >= 3.2

### DIFF
--- a/guide-extension/pom.xml
+++ b/guide-extension/pom.xml
@@ -3,13 +3,13 @@
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-guide-extension</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.1</version>
+    <version>3.2.3</version>
     <name>Neo4j-Web</name>
     <description>Neo4j Web Extension</description>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.6</slf4j.version>
-        <neo4j.version>3.0.1</neo4j.version>
+        <neo4j.version>3.2.3</neo4j.version>
         <jersey.version>1.19</jersey.version>
     </properties>
 

--- a/guide-extension/src/main/java/extension/web/StaticWebResource.java
+++ b/guide-extension/src/main/java/extension/web/StaticWebResource.java
@@ -27,7 +27,7 @@ public class StaticWebResource {
 
 	public StaticWebResource(@Context Config configuration, @Context WebServer server) {
 
-        String path = configuration.getParams().get("org.neo4j.server.guide.directory");
+        String path = configuration.getRaw().get("org.neo4j.server.guide.directory");
         if (path == null) path = "guides";
         File file = new File(path);
 		this.directory = file.exists() ? file : null;


### PR DESCRIPTION
Closes https://github.com/neo4j-contrib/neo4j-guides/issues/14.

Uses solution from https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/4dcf50ad2e6ae2f4b4fb0eb6bf9cd1f2ca80d185

After merging, I'd recommend creating a new release that uploads `neo4j-guide-extension-3.2.3.jar`.