### PR TITLE
(feat) Supports non-cypher blocks, such as shell. 

### DIFF
--- a/templates/block_listing.html.erb
+++ b/templates/block_listing.html.erb
@@ -1,8 +1,8 @@
 <%#encoding:UTF-8%><div<%= @id && %( id="#{@id}") %> class="<%= ['listingblock',role].compact * ' ' %>"><%
 if title? %>
 <div class="title"><%= captioned_title %></div><%
-end %>
-<div class="content"><%
+end
+
 nowrap = !(@document.attr? :prewrap) || (option? :nowrap)
 if @style == 'source'
   language = attr :language
@@ -27,15 +27,18 @@ if @style == 'source'
   end
   pre_class << "pre-scrollable"
   pre_class << "programlisting"
-  pre_class << "cm-s-neo"
-  pre_class << "code"
-  pre_class << "runnable"
-  pre_class << "standalone-example"
-  pre_class << "ng-binding" 
+
+  if code_class.include? 'cypher'
+    pre_class << "code"
+    pre_class << "cm-s-neo"
+    pre_class << "runnable"
+    pre_class << "standalone-example"
+    pre_class << "ng-binding"
+  end
+
   pre_class << 'nowrap' if nowrap %>
 <pre mode="cypher" <%= pre_class.empty? ? nil : %( class="#{pre_class * ' '}") %><%= pre_lang && %( data-lang="#{pre_lang}") %><%= pre_lang && %( lang="#{pre_lang}") %>><!--code<%= code_class.empty? ? nil : %( class="#{code_class * ' '}") %>--><%= content %><!--/code--></pre><%
 else %>
 <pre<%= nowrap ? ' class="nowrap"' : nil %>><%= content %></pre><%
 end %>
-</div>
 </div>


### PR DESCRIPTION
These blocks are non-runnable.  

This also removes the `<div content>` wrapper as it was stopping non-runnable `<pre>` blocks from having their background set correctly.